### PR TITLE
Expose crawl duration / Support Crawl Logs output

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,11 +76,13 @@ Opening Browser 1 of 1 (CKVEMACNI6YBUKLQI6UKKBLB) for crawl cf30281efc7a
 To view all running crawls, simply run `browsertrix crawl list` which should result in output similar to:
 
 ```
-CRAWL ID      NAME          STARTED       STATUS   CRAWL TYPE    COLL              MODE      TO CRAWL  PENDING   SEEN      BROWSERS   TABS  
-cf30281efc7a  example       0:00:35 ago   running  all-links     example           record    15        1         25        1          1    
+CRAWL ID      NAME          STARTED       DURATION      STATUS   CRAWL TYPE    COLL              MODE      TO CRAWL  PENDING   SEEN      BROWSERS   TABS  
+cf30281efc7a  example       0:00:35 ago   0:00:10       running  all-links     example           record    15        1         25        1          1    
 ```
 
 To get more detailed info on the crawl, run `browsertrix crawl info --urls <crawl_id>` (where `<crawl_id> = cf30281efc7a` in this example)
+
+To follow the crawl log in the console window, add the `--log` option (the log followed will be from the first browser).
 
 ### Crawling Options
 
@@ -174,7 +176,9 @@ Sample record and replay configs, [social-media.yaml](sample-crawls/social-media
 
 Other crawl operations include:
 * `browsertrix crawl stop` for stopping a crawl
+* `browsertrix crawl logs` for printing and following logs for one or all crawlers
 * `browsertrix crawl watch <crawl_id>` for attaching and watching all the browsers in a given crawl.
+* `browsertrix crawl remove` for removing a crawl
 * `browsertrix crawl remove-all` for stopping and removing all crawls.
 
 See `browsertrix crawl -h` for a complete reference of available commands.

--- a/browsertrix/api.py
+++ b/browsertrix/api.py
@@ -12,12 +12,12 @@ crawl_router = APIRouter()
 
 
 # ============================================================================
-@app.post('/crawls', response_model=CreateStartResponse, content_type=UJSONResponse)
+@app.post('/crawls', response_model=CreateStartResponse, response_class=UJSONResponse)
 async def create_crawl(new_crawl: CreateCrawlRequest):
     return await crawl_man.create_new(new_crawl)
 
 
-@app.get('/crawls', response_model=CrawlInfosResponse, content_type=UJSONResponse)
+@app.get('/crawls', response_model=CrawlInfosResponse, response_class=UJSONResponse)
 async def get_all_crawls():
     return await crawl_man.get_all_crawls()
 
@@ -25,7 +25,7 @@ async def get_all_crawls():
 @crawl_router.put(
     '/{crawl_id}/urls',
     response_model=OperationSuccessResponse,
-    content_type=UJSONResponse,
+    response_class=UJSONResponse,
 )
 async def queue_urls(crawl_id: str, url_list: QueueUrlsRequest):
     crawl = await crawl_man.load_crawl(crawl_id)
@@ -33,7 +33,7 @@ async def queue_urls(crawl_id: str, url_list: QueueUrlsRequest):
 
 
 @crawl_router.get(
-    '/{crawl_id}', response_model=CrawlInfoResponse, content_type=UJSONResponse
+    '/{crawl_id}', response_model=CrawlInfoResponse, response_class=UJSONResponse
 )
 async def get_crawl(crawl_id: str):
     crawl = await crawl_man.load_crawl(crawl_id)
@@ -41,7 +41,7 @@ async def get_crawl(crawl_id: str):
 
 
 @crawl_router.get(
-    '/{crawl_id}/urls', response_model=CrawlInfoUrlsResponse, content_type=UJSONResponse
+    '/{crawl_id}/urls', response_model=CrawlInfoUrlsResponse, response_class=UJSONResponse
 )
 async def get_crawl_urls(crawl_id: str):
     crawl = await crawl_man.load_crawl(crawl_id)
@@ -49,14 +49,14 @@ async def get_crawl_urls(crawl_id: str):
 
 
 @crawl_router.get(
-    '/{crawl_id}/info', response_model=FullCrawlInfoResponse, content_type=UJSONResponse
+    '/{crawl_id}/info', response_model=FullCrawlInfoResponse, response_class=UJSONResponse
 )
 async def get_full_crawl_info(crawl_id: str):
     return await crawl_man.get_full_crawl_info(crawl_id)
 
 
 @crawl_router.post(
-    '/{crawl_id}/start', response_model=CreateStartResponse, content_type=UJSONResponse
+    '/{crawl_id}/start', response_model=CreateStartResponse, response_class=UJSONResponse
 )
 async def start_crawl(crawl_id: str):
     crawl = await crawl_man.load_crawl(crawl_id)
@@ -66,7 +66,7 @@ async def start_crawl(crawl_id: str):
 @crawl_router.post(
     '/{crawl_id}/stop',
     response_model=OperationSuccessResponse,
-    content_type=UJSONResponse,
+    response_class=UJSONResponse,
 )
 async def stop_crawl(crawl_id: str):
     crawl = await crawl_man.load_crawl(crawl_id)
@@ -74,7 +74,7 @@ async def stop_crawl(crawl_id: str):
 
 
 @crawl_router.get(
-    '/{crawl_id}/done', response_model=CrawlDoneResponse, content_type=UJSONResponse
+    '/{crawl_id}/done', response_model=CrawlDoneResponse, response_class=UJSONResponse
 )
 async def is_done_crawl(crawl_id: str):
     crawl = await crawl_man.load_crawl(crawl_id)
@@ -82,7 +82,7 @@ async def is_done_crawl(crawl_id: str):
 
 
 @crawl_router.delete(
-    '/{crawl_id}', response_model=OperationSuccessResponse, content_type=UJSONResponse
+    '/{crawl_id}', response_model=OperationSuccessResponse, response_class=UJSONResponse
 )
 async def delete_crawl(crawl_id: str):
     crawl = await crawl_man.load_crawl(crawl_id)

--- a/browsertrix/api.py
+++ b/browsertrix/api.py
@@ -41,7 +41,9 @@ async def get_crawl(crawl_id: str):
 
 
 @crawl_router.get(
-    '/{crawl_id}/urls', response_model=CrawlInfoUrlsResponse, response_class=UJSONResponse
+    '/{crawl_id}/urls',
+    response_model=CrawlInfoUrlsResponse,
+    response_class=UJSONResponse,
 )
 async def get_crawl_urls(crawl_id: str):
     crawl = await crawl_man.load_crawl(crawl_id)
@@ -49,14 +51,18 @@ async def get_crawl_urls(crawl_id: str):
 
 
 @crawl_router.get(
-    '/{crawl_id}/info', response_model=FullCrawlInfoResponse, response_class=UJSONResponse
+    '/{crawl_id}/info',
+    response_model=FullCrawlInfoResponse,
+    response_class=UJSONResponse,
 )
 async def get_full_crawl_info(crawl_id: str):
     return await crawl_man.get_full_crawl_info(crawl_id)
 
 
 @crawl_router.post(
-    '/{crawl_id}/start', response_model=CreateStartResponse, response_class=UJSONResponse
+    '/{crawl_id}/start',
+    response_model=CreateStartResponse,
+    response_class=UJSONResponse,
 )
 async def start_crawl(crawl_id: str):
     crawl = await crawl_man.load_crawl(crawl_id)

--- a/browsertrix/crawl.py
+++ b/browsertrix/crawl.py
@@ -577,11 +577,11 @@ class Crawl:
             return {'done': False}
 
         # if frontier not empty, not done
-        #if await self.redis.llen(self.frontier_q_key) > 0:
+        # if await self.redis.llen(self.frontier_q_key) > 0:
         #    return {'done': False}
 
         # if pending q not empty, not done
-        #if await self.redis.scard(self.pending_q_key) > 0:
+        # if await self.redis.scard(self.pending_q_key) > 0:
         #    return {'done': False}
 
         # if not all browsers are done, not done

--- a/browsertrix/schema.py
+++ b/browsertrix/schema.py
@@ -95,7 +95,7 @@ class CrawlInfoResponse(BaseCreateCrawl):
     start_time: int = 0
     finish_time: int = 0
     browsers: OptionalList
-    browsers_done: List[Dict[Any, Any]]
+    tabs_done: List[Dict[Any, Any]]
     headless: bool = False
     num_queue: int = 0
     num_seen: int = 0

--- a/browsertrix/schema.py
+++ b/browsertrix/schema.py
@@ -93,8 +93,9 @@ class CrawlInfoResponse(BaseCreateCrawl):
     id: str
     status: str = 'new'
     start_time: int = 0
+    finish_time: int = 0
     browsers: OptionalList
-    browsers_done: OptionalList
+    browsers_done: List[Dict[Any, Any]]
     headless: bool = False
     num_queue: int = 0
     num_seen: int = 0
@@ -121,6 +122,7 @@ class CrawlInfo(BaseModel):
     num_browsers: int
     num_tabs: int
     start_time: int = 0
+    finish_time: int = 0
     headless: bool = False
 
 

--- a/browsertrix_cli/crawl.py
+++ b/browsertrix_cli/crawl.py
@@ -103,15 +103,18 @@ def print_logs(browsers, follow=False, wait=False):
 def open_browsers(browsers, crawl_id, tabs_done=None, num_tabs=-1):
     count = 1
     for reqid in browsers:
-        if tabs_done and tabs_done.get(reqid) != num_tabs:
+        skip = False
+        if not tabs_done or tabs_done.get(reqid) != num_tabs:
             msg = 'Opening Browser {0} of {1} ({2}) for crawl {3}'
         else:
             msg = 'Skipping Finished Browser {0} of {1}, ({2}) for crawl {3}'
+            skip = True
 
         if not is_quiet():
             print(msg.format(count, len(browsers), reqid, crawl_id))
 
-        webbrowser.open(settings.view_browsers_prefix + reqid)
+        if not skip:
+            webbrowser.open(settings.view_browsers_prefix + reqid)
         count += 1
 
 
@@ -368,7 +371,6 @@ def watch_crawl(crawl_id):
                 print('No Browsers')
                 continue
 
-        print(done_count, res['num_tabs'])
         open_browsers(browsers, id_, done_count, res['num_tabs'])
 
 
@@ -455,7 +457,6 @@ def logs(crawl_id, browser, follow):
     :param follow: follow crawl log in real-time (for one browser only)
     """
     res = sesh_get('/crawl/{0}'.format(crawl_id))
-
 
     num_browsers = len(res['browsers'])
     if browser <= 0:

--- a/browsertrix_cli/crawl.py
+++ b/browsertrix_cli/crawl.py
@@ -19,6 +19,7 @@ COLUMNS = [
     ('id', 'CRAWL ID', 12),
     ('name', 'NAME', 12),
     ('start_time', 'STARTED', 12),
+    ('finish_time', 'DURATION', 12),
     ('status', 'STATUS', 7),
     ('crawl_type', 'CRAWL TYPE', 12),
     ('coll', 'COLL', 16),
@@ -38,21 +39,27 @@ def crawl():
 
 
 # ============================================================================
-def format_elapsed(timestr):
-    """ Format given time as elapsed from now
+def format_duration(start_time, finish_time):
+    """ Format duration of crawl
 
-    :param timestr: Time in seconds as str or int
+    :param start_time: start time of crawl
+    :param finish_time: finish time of crawl
     :return: string text for time elapsed since timestr
     """
     try:
-        if timestr == 0:
+        if start_time == 0:
             return '-'
-        text = datetime.datetime.fromtimestamp(int(timestr))
-        elapsed = datetime.datetime.now() - text
-        return str(elapsed).split('.', 1)[0] + ' ago'
+
+        if not finish_time:
+            finish = datetime.datetime.now()
+        else:
+            finish = datetime.datetime.fromtimestamp(int(finish_time))
+
+        start = datetime.datetime.fromtimestamp(int(start_time))
+        elapsed = finish - start
+        return str(elapsed).split('.', 1)[0]
     except Exception:
         return timestr
-
 
 # ============================================================================
 def open_browsers(browsers, browsers_done, crawl_id):
@@ -95,7 +102,9 @@ def list_crawls():
         for field, _, size in COLUMNS:
             value = crawl[field]
             if field == 'start_time':
-                value = format_elapsed(value)
+                value = format_duration(value, None) + ' ago'
+            elif field == 'finish_time':
+                value = format_duration(crawl['start_time'], value)
 
             sys.stdout.write(format_str.format(value=value, size=size))
         print()

--- a/browsertrix_cli/crawl.py
+++ b/browsertrix_cli/crawl.py
@@ -274,6 +274,9 @@ def create_crawl(
         if screenshot_coll is not None:
             crawl_spec['screenshot_coll'] = screenshot_coll
 
+        if not is_quiet():
+            print('Creating New Crawl, Please Wait...')
+
         res = sesh_post('/crawls', json=crawl_spec)
 
         if is_quiet():

--- a/pywb/Dockerfile
+++ b/pywb/Dockerfile
@@ -1,4 +1,4 @@
-FROM webrecorder/pywb
+FROM webrecorder/pywb:new-wombat
 
 WORKDIR /app
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ aiohttp
 aioredis
 better_exceptions
 cchardet
-fastapi
+fastapi==0.19.0
 pyyaml
 ujson
 uvloop

--- a/sample-crawls/example.yaml
+++ b/sample-crawls/example.yaml
@@ -1,6 +1,6 @@
 crawls:
   - name: example
-    crawl_type: all-links
+    crawl_type: single-page
     num_browsers: 1
 
     coll: example

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ setup(
     entry_points="""
         [console_scripts]
         browsertrix=browsertrix_cli.main:cli
+        btrix=browsertrix_cli.main:cli
     """,
     test_suite='',
     tests_require=load_requirements('test-local-requirements.txt'),

--- a/tests/test_live_crawl.py
+++ b/tests/test_live_crawl.py
@@ -17,7 +17,7 @@ class TestCrawls(object):
         for crawl_id in cls.all_crawl_ids:
             res = requests.delete(cls.api_host + '/crawl/' + crawl_id)
             res = res.json()
-            assert res.get('success') or res.get('detail') == 'not found'
+            assert res.get('success') or res.get('detail') == 'crawl not found'
 
     def test_crawl_create_and_start(self, crawl, headless):
         crawl['headless'] = headless

--- a/tests/test_live_crawl.py
+++ b/tests/test_live_crawl.py
@@ -53,9 +53,9 @@ class TestCrawls(object):
                 break
 
             if time.time() - start_time > max_time:
-                print('Waiting for crawl done')
                 break
 
+            print('Waiting for crawl done')
             time.sleep(sleep_time)
 
         assert done


### PR DESCRIPTION
- add 'finish_time' to crawl info, display crawl duration in cli for finished crawls
- add 'browsertrix logs' command to print all logs, single browser and optionally follow log
- add --log param to create to follow first browser log
- use shepherd /flock/stop endpoint to stop (but not remove) flock so logs remain available
- use shepherd /flock/remove endpoint to remove crawls
- split 'browsertrix crawl --remove stop' into dedicated 'browsertrix crawl remove' command