### PR TITLE
crawl request fixes:

### DIFF
--- a/browsertrix/schema.py
+++ b/browsertrix/schema.py
@@ -64,6 +64,9 @@ class BaseCreateCrawl(BaseModel):
 
 
 class CreateCrawlRequest(BaseCreateCrawl):
+    class Config:
+        extra = 'forbid'
+
     seed_urls: List[UrlStr] = []
     scopes: List[Dict[Any, Any]] = []
 
@@ -71,6 +74,8 @@ class CreateCrawlRequest(BaseCreateCrawl):
 
     browser: Optional[str] = 'chrome:73'
     user_params: Dict[Any, Any] = dict()
+
+    ignore_extra: Optional[Dict[Any, Any]] = None
 
     behavior_max_time: int = 0
     headless: bool = False

--- a/browsertrix_cli/crawl.py
+++ b/browsertrix_cli/crawl.py
@@ -278,7 +278,10 @@ def create_crawl(
             crawl_spec['behavior_time'] = behavior_time
 
         if profile is not None:
-            browser = get_profile_image(profile)
+            crawl_spec['profile'] = profile
+
+        if 'profile' in crawl_spec:
+            browser = get_profile_image(crawl_spec.get('profile', ''))
 
         if browser is not None:
             crawl_spec['browser'] = browser

--- a/tests/crawl_tests.yaml
+++ b/tests/crawl_tests.yaml
@@ -17,8 +17,8 @@ crawls:
     browser: chrome:73
 
     # params for test only
-    test_params:
-      max_timeout: 120
+    ignore_extra:
+      test_max_timeout: 120
 
   - name: all-links-single-page
     crawl_type: all-links
@@ -34,11 +34,11 @@ crawls:
     browser: chrome:73
 
     # params for test only
-    test_params:
-      max_timeout: 600
+    ignore_extra:
+      test_max_timeout: 600
 
       # expected size of seen list
-      expected_seen: 51
+      test_expected_seen: 51
    
   - name: multi-browser-test
     crawl_type: single-page
@@ -55,6 +55,6 @@ crawls:
     browser: chrome:73
 
     # params for test only
-    test_params:
-      max_timeout: 300
+    ignore_extra:
+      test_max_timeout: 300
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -74,7 +74,6 @@ class TestCrawlAPI:
         )
 
         res = res.json()
-        print(res)
         assert res['success']
         TestCrawlAPI.crawl_id = res['id']
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -58,7 +58,7 @@ class TestCrawlAPI:
             'browser': 'chrome:67',
             'screenshot_target_uri': 'file://test',
             'user_params': {'some': 'value', 'some_int': 7},
-            'behavior_run_time': 30,
+            'behavior_max_time': 30,
             'headless': False,
             'start': False,
             'num_tabs': 2,
@@ -74,6 +74,7 @@ class TestCrawlAPI:
         )
 
         res = res.json()
+        print(res)
         assert res['success']
         TestCrawlAPI.crawl_id = res['id']
 
@@ -306,7 +307,7 @@ class TestCrawlAPI:
                              'browser': 'chrome:67',
                              'screenshot_target_uri': 'file://test',
                              'user_params': {'some': 'value', 'some_int': 7},
-                             'behavior_run_time': 30,
+                             'behavior_max_time': 30,
                              'headless': True,
                              'start': True,
                              }

--- a/tests/test_live_crawl.py
+++ b/tests/test_live_crawl.py
@@ -44,7 +44,7 @@ class TestCrawls(object):
     def test_sleep_wait(self, crawl):
         start_time = time.time()
         sleep_time = 5
-        max_time = crawl.get('max_timeout', 600) + 30
+        max_time = crawl.get('ignore_extra', {}).get('test_max_timeout', 600) + 30
         done = False
         while True:
             res = requests.get(self.api_host + f'/crawl/{self.crawl_id}/done')
@@ -68,8 +68,9 @@ class TestCrawls(object):
         assert len(res['pending']) == 0
 
         assert len(res['seen']) >= len(crawl['seed_urls'])
-        if crawl.get('expected_seen'):
-            assert len(res['seen']) == crawl.get('expected_seen')
+        expected_seen = crawl.get('ignore_extra', {}).get('test_expected_seen')
+        if expected_seen:
+            assert len(res['seen']) == expected_seen
 
         TestCrawls.seen = res['seen']
 

--- a/tests/test_live_crawl.py
+++ b/tests/test_live_crawl.py
@@ -24,11 +24,9 @@ class TestCrawls(object):
         if 'browser' not in crawl:
             crawl['browser'] = self.default_browser
 
-        print(crawl)
         res = requests.post(self.api_host + '/crawls', json=crawl)
         res = res.json()
 
-        print(res)
         assert res.get('success'), res
         assert len(res['browsers']) == crawl.get('num_browsers', 1)
 
@@ -63,7 +61,6 @@ class TestCrawls(object):
     def test_get_stats(self, crawl):
         res = requests.get(self.api_host + f'/crawl/{self.crawl_id}/urls')
         res = res.json()
-        print(res)
         assert len(res['queue']) == 0
         assert len(res['pending']) == 0
 


### PR DESCRIPTION
- ensure 'profile' in crawl request is used if specified
- ensure unknown fields in crawl spec are rejected.. add 'ignore_extra' key for additional fields ignored by crawl (eg. extra test keys)
- fix tests to use new 'ignore_extra' key