### PR TITLE
Better domain extraction for same-domain crawls and browser overrides serialization fixes  

### DIFF
--- a/browsertrix/api.py
+++ b/browsertrix/api.py
@@ -28,16 +28,14 @@ async def get_all_crawls():
     response_class=UJSONResponse,
 )
 async def queue_urls(crawl_id: str, url_list: QueueUrlsRequest):
-    crawl = await crawl_man.load_crawl(crawl_id)
-    return await crawl.queue_urls(url_list.urls)
+    return await crawl_man.queue_crawl_urls(crawl_id, url_list.urls)
 
 
 @crawl_router.get(
     '/{crawl_id}', response_model=CrawlInfoResponse, response_class=UJSONResponse
 )
 async def get_crawl(crawl_id: str):
-    crawl = await crawl_man.load_crawl(crawl_id)
-    return await crawl.get_info()
+    return await crawl_man.get_crawl_info(crawl_id)
 
 
 @crawl_router.get(
@@ -46,8 +44,7 @@ async def get_crawl(crawl_id: str):
     response_class=UJSONResponse,
 )
 async def get_crawl_urls(crawl_id: str):
-    crawl = await crawl_man.load_crawl(crawl_id)
-    return await crawl.get_info_urls()
+    return await crawl_man.get_crawl_urls(crawl_id)
 
 
 @crawl_router.get(
@@ -65,8 +62,7 @@ async def get_full_crawl_info(crawl_id: str):
     response_class=UJSONResponse,
 )
 async def start_crawl(crawl_id: str):
-    crawl = await crawl_man.load_crawl(crawl_id)
-    return await crawl.start()
+    return await crawl_man.start_crawl(crawl_id)
 
 
 @crawl_router.post(
@@ -75,24 +71,21 @@ async def start_crawl(crawl_id: str):
     response_class=UJSONResponse,
 )
 async def stop_crawl(crawl_id: str):
-    crawl = await crawl_man.load_crawl(crawl_id)
-    return await crawl.stop()
+    return await crawl_man.stop_crawl(crawl_id)
 
 
 @crawl_router.get(
     '/{crawl_id}/done', response_model=CrawlDoneResponse, response_class=UJSONResponse
 )
 async def is_done_crawl(crawl_id: str):
-    crawl = await crawl_man.load_crawl(crawl_id)
-    return await crawl.is_done()
+    return await crawl_man.is_crawl_done(crawl_id)
 
 
 @crawl_router.delete(
     '/{crawl_id}', response_model=OperationSuccessResponse, response_class=UJSONResponse
 )
 async def delete_crawl(crawl_id: str):
-    crawl = await crawl_man.load_crawl(crawl_id)
-    return await crawl.delete()
+    return await crawl_man.delete_crawl(crawl_id)
 
 
 @app.route('/')

--- a/browsertrix/api.py
+++ b/browsertrix/api.py
@@ -7,6 +7,9 @@ from .crawl import CrawlManager
 from .schema import *
 
 app = FastAPI(debug=True)
+app.add_middleware(
+    CORSMiddleware, allow_origins=["*"], allow_methods=ALL_METHODS, allow_headers=["*"]
+)
 crawl_man = CrawlManager()
 crawl_router = APIRouter()
 
@@ -93,7 +96,6 @@ def ui(*args, **kwargs):
     return FileResponse('static/index.html')
 
 
-app.add_middleware(CORSMiddleware, allow_origins=['*'], allow_methods=ALL_METHODS)
 app.include_router(crawl_router, prefix='/crawl', tags=['crawl'])
 app.mount('/static', StaticFiles(directory='static', check_dir=True), 'static')
 app.add_event_handler('startup', crawl_man.startup)

--- a/browsertrix/utils.py
+++ b/browsertrix/utils.py
@@ -1,11 +1,12 @@
 from asyncio import AbstractEventLoop
 from os import environ
 from typing import Any, Dict, Optional, Type, Union
-from ujson import loads as ujson_loads
+from urllib.parse import urlsplit
 
 from aioredis import Redis, create_redis
+from ujson import loads as ujson_loads
 
-__all__ = ['env', 'init_redis']
+__all__ = ['env', 'extract_domain', 'init_redis']
 
 
 async def init_redis(redis_url: str, loop: AbstractEventLoop) -> Redis:
@@ -63,3 +64,14 @@ def env(
             )
     elif type_ == dict:
         return ujson_loads(val)
+
+
+def extract_domain(url: str) -> str:
+    """Extracts and returns the domain, including the suffix,
+    of the supplied URL
+
+    :param url: The url to have its domain extracted from
+    :return: The extracted domain
+    """
+    extracted = urlsplit(url).netloc
+    return extracted.replace('www.', '')

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ aiohttp
 aioredis
 better_exceptions
 cchardet
-fastapi==0.27.2
+fastapi==0.29.0
 pyyaml
 ujson
 uvloop

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ aiohttp
 aioredis
 better_exceptions
 cchardet
-fastapi==0.19.0
+fastapi==0.27.2
 pyyaml
 ujson
 uvloop


### PR DESCRIPTION
use tldextract to create the domain rule since urlcannon's domain based match rules do not work well with "www" as it is counted as apart of the domain which is the result of using urllib.parse.urlsplit

ensure no serialization errors occur when browser overrides are used
fixed readme typo
bumped fastapi version to latest