### PR TITLE
No longer use hard-coded crawl depths  

### DIFF
--- a/browsertrix/api.py
+++ b/browsertrix/api.py
@@ -4,7 +4,17 @@ from starlette.responses import FileResponse, UJSONResponse
 from starlette.staticfiles import StaticFiles
 
 from .crawl import CrawlManager
-from .schema import *
+from .schema import (
+    CrawlDoneResponse,
+    CrawlInfoResponse,
+    CrawlInfoUrlsResponse,
+    CrawlInfosResponse,
+    CreateCrawlRequest,
+    CreateStartResponse,
+    FullCrawlInfoResponse,
+    OperationSuccessResponse,
+    QueueUrlsRequest,
+)
 
 app = FastAPI(debug=True)
 app.add_middleware(

--- a/browsertrix/crawl.py
+++ b/browsertrix/crawl.py
@@ -33,9 +33,9 @@ class CrawlManager:
         self.redis: Optional[Redis] = None
         self.session: Optional[ClientSession] = None
         self.loop: OptionalLoop = None
-        self.default_depth: int = env('DEFAULT_DEPTH', type_=int, default=-1)
+        self.default_depth: int = env('DEFAULT_DEPTH', type_=int, default=250)
         self.default_same_domain_depth: int = env(
-            'DEFAULT_SAME_DOMAIN_DEPTH', type_=int, default=-1
+            'DEFAULT_SAME_DOMAIN_DEPTH', type_=int, default=self.default_depth
         )
 
         self.num_browsers: int = env('DEFAULT_NUM_BROWSERS', type_=int, default=2)
@@ -407,7 +407,7 @@ class Crawl:
 
         for url in urls:
             await self.redis.sadd(
-                self.scopes_key, json.dumps({'domain': extract_domain(url)})
+                self.scopes_key, json.dumps({'domain': extract_domain(url), 'strict': True})
             )
 
     async def queue_urls(self, urls: List[str]) -> Dict[str, bool]:

--- a/browsertrix/schema.py
+++ b/browsertrix/schema.py
@@ -1,8 +1,19 @@
-import math
 from enum import Enum
-from typing import Any, Dict, List, Optional, Set, Union
+from typing import Dict, List, Optional
 
-from pydantic import BaseModel, Schema, UrlStr
+from pydantic import BaseModel, Extra, Schema, UrlStr
+
+from .types_ import (
+    AnyDict,
+    AnyDictList,
+    Number,
+    OptionalAnyDict,
+    OptionalBool,
+    OptionalNumber,
+    OptionalSetStr,
+    OptionalStr,
+    OptionalStrList,
+)
 
 __all__ = [
     'BrowserCookie',
@@ -26,11 +37,8 @@ __all__ = [
 ]
 
 # ============================================================================
-OptionalList = Optional[List[str]]
-OptionalSet = Optional[Set[str]]
-Number = Union[int, float]
 
-UrlStr.max_length = math.inf
+UrlStr.max_length = None  # type: ignore
 UrlStr.relative = True
 
 
@@ -63,11 +71,11 @@ class CookieSameSite(str, Enum):
 class EmulatedDevice(BaseModel):
     width: Number
     height: Number
-    deviceScaleFactor: Optional[Number] = None
-    maxTouchPoints: Optional[Number] = None
-    isMobile: Optional[bool] = None
-    hasTouch: Optional[bool] = None
-    isLandscape: Optional[bool] = None
+    deviceScaleFactor: OptionalNumber = None
+    maxTouchPoints: OptionalNumber = None
+    isMobile: OptionalBool = None
+    hasTouch: OptionalBool = None
+    isLandscape: OptionalBool = None
 
 
 class EmulatedGeoLocation(BaseModel):
@@ -79,18 +87,18 @@ class BrowserCookie(BaseModel):
     name: str
     value: str
     url: Optional[UrlStr] = None
-    domain: Optional[str] = None
-    path: Optional[str] = None
-    secure: Optional[bool] = None
-    httpOnly: Optional[bool] = None
-    expires: Optional[Number] = None
+    domain: OptionalStr = None
+    path: OptionalStr = None
+    secure: OptionalBool = None
+    httpOnly: OptionalBool = None
+    expires: OptionalNumber = None
     sameSite: Optional[CookieSameSite] = None
 
 
 class BrowserOverrides(BaseModel):
-    user_agent: Optional[str] = None
-    accept_language: Optional[str] = None
-    navigator_platform: Optional[str] = None
+    user_agent: OptionalStr = None
+    accept_language: OptionalStr = None
+    navigator_platform: OptionalStr = None
     extra_headers: Optional[Dict[str, str]] = None
     cookies: Optional[List[BrowserCookie]] = None
     geo_location: Optional[EmulatedGeoLocation] = None
@@ -98,47 +106,56 @@ class BrowserOverrides(BaseModel):
 
 
 class BaseCreateCrawl(BaseModel):
-    crawl_type: CrawlType = Schema(
+    crawl_type: CrawlType = Schema(  # type: ignore
         CrawlType.SINGLE_PAGE, description='What type of crawl should be launched'
     )
-    crawl_depth: Optional[int] = None
-    num_browsers: int = Schema(
+    crawl_depth: int = Schema(  # type: ignore
+        -1,
+        description='How may pages out from the starting seed(s) should the crawl go',
+    )
+    num_browsers: int = Schema(  # type: ignore
         2, description='How many browsers should be used for the crawl'
     )
-    num_tabs: int = Schema(1, description='How many tabs should be used for the crawl')
-    name: Optional[str] = Schema('', description='User friendly name for the crawl')
-    coll: Optional[str] = Schema('live', description='Default Collection')
+    num_tabs: int = Schema(
+        1, description='How many tabs should be used for the crawl'
+    )  # type: ignore
+    name: OptionalStr = Schema(
+        '', description='User friendly name for the crawl'
+    )  # type: ignore
+    coll: OptionalStr = Schema('live', description='Default Collection')  # type: ignore
 
-    mode: CaptureMode = Schema(CaptureMode.RECORD, description='Default Mode')
+    mode: CaptureMode = Schema(
+        CaptureMode.RECORD, description='Default Mode'
+    )  # type: ignore
 
-    screenshot_coll: Optional[str] = Schema(
+    screenshot_coll: OptionalStr = Schema(  # type: ignore
         '', description='Collection to store screenshots, if any'
     )
 
-    text_coll: Optional[str] = Schema(
+    text_coll: OptionalStr = Schema(  # type: ignore
         '', description='Collection to store full-text indexes, if any'
     )
 
 
 class CreateCrawlRequest(BaseCreateCrawl):
     class Config:
-        extra = 'forbid'
+        extra: Extra = Extra.forbid
 
     seed_urls: List[UrlStr] = []
-    scopes: List[Dict[Any, Any]] = []
+    scopes: AnyDictList = []
 
     cache: CacheMode = CacheMode.ALWAYS
 
-    browser: Optional[str] = 'chrome:73'
-    user_params: Dict[Any, Any] = dict()
+    browser: OptionalStr = 'chrome:73'
+    user_params: AnyDict = {}
 
-    profile: Optional[str] = None
+    profile: OptionalStr = None
 
-    ignore_extra: Optional[Dict[Any, Any]] = None
+    ignore_extra: OptionalAnyDict = None
 
-    behavior_max_time: int = 0
+    behavior_max_time: Number = 0
     headless: bool = False
-    screenshot_target_uri: Optional[str] = None
+    screenshot_target_uri: OptionalStr = None
 
     start: bool = True
     browser_overrides: Optional[BrowserOverrides] = None
@@ -159,8 +176,8 @@ class CrawlInfoResponse(BaseCreateCrawl):
     status: str = 'new'
     start_time: int = 0
     finish_time: int = 0
-    browsers: OptionalList
-    tabs_done: List[Dict[Any, Any]]
+    browsers: OptionalStrList
+    tabs_done: AnyDictList
     headless: bool = False
     num_queue: int = 0
     num_seen: int = 0
@@ -194,10 +211,10 @@ class CrawlInfo(BaseModel):
 
 
 class CrawlInfoUrlsResponse(BaseModel):
-    scopes: List[Dict[Any, Any]]
-    queue: List[Dict[Any, Any]]
-    pending: OptionalList
-    seen: OptionalSet
+    scopes: AnyDictList
+    queue: AnyDictList
+    pending: OptionalStrList
+    seen: OptionalSetStr
 
 
 class FullCrawlInfoResponse(CrawlInfo, CrawlInfoUrlsResponse):

--- a/browsertrix/types_.py
+++ b/browsertrix/types_.py
@@ -1,0 +1,35 @@
+from asyncio import AbstractEventLoop
+from typing import Any, Dict, List, Optional, Set, Type, Union
+
+__all__ = [
+    'AnyDict',
+    'AnyDictList',
+    'EnvType',
+    'EnvValue',
+    'Loop',
+    'Number',
+    'OptionalAny',
+    'OptionalAnyDict',
+    'OptionalBool',
+    'OptionalLoop',
+    'OptionalNumber',
+    'OptionalSetStr',
+    'OptionalStr',
+    'OptionalStrList',
+]
+
+AnyDict = Dict[Any, Any]
+AnyDictList = List[AnyDict]
+Loop = AbstractEventLoop
+Number = Union[int, float]
+EnvValue = Union[str, bool, dict, Number]
+EnvType = Type[EnvValue]
+
+OptionalAny = Optional[Any]
+OptionalAnyDict = Optional[AnyDict]
+OptionalBool = Optional[bool]
+OptionalLoop = Optional[Loop]
+OptionalNumber = Optional[Number]
+OptionalSetStr = Optional[Set[str]]
+OptionalStr = Optional[str]
+OptionalStrList = Optional[List[str]]

--- a/browsertrix/utils.py
+++ b/browsertrix/utils.py
@@ -1,23 +1,19 @@
-from asyncio import AbstractEventLoop
 from os import environ
-from typing import Any, Dict, Optional, Type, Union
 from urllib.parse import urlsplit
 
 from aioredis import Redis, create_redis
-from ujson import loads as ujson_loads
+from ujson import loads
+
+from .types_ import EnvType, EnvValue, Loop, OptionalAny
 
 __all__ = ['env', 'extract_domain', 'init_redis']
 
 
-async def init_redis(redis_url: str, loop: AbstractEventLoop) -> Redis:
+async def init_redis(redis_url: str, loop: Loop) -> Redis:
     return await create_redis(redis_url, encoding='utf-8', loop=loop)
 
 
-def env(
-    key: str,
-    type_: Type[Union[str, bool, int, dict, float]] = str,
-    default: Optional[Any] = None,
-) -> Union[str, int, bool, float, Dict]:
+def env(key: str, type_: EnvType = str, default: OptionalAny = None) -> EnvValue:
     """Returns the value of the supplied env key name converting
     the env key's value to the specified type.
 
@@ -63,7 +59,7 @@ def env(
                 f'Invalid environment variable "{key}" (expected a float): "{val}"'
             )
     elif type_ == dict:
-        return ujson_loads(val)
+        return loads(val)
 
 
 def extract_domain(url: str) -> str:

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ aiohttp
 aioredis
 better_exceptions
 cchardet
-fastapi==0.29.0
+fastapi==0.31.0
 pyyaml
 ujson
 uvloop

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-black -S -v browsertrix browsertrix_cli pywb
+black -S -v browsertrix browsertrix_cli tests pywb

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,6 +18,7 @@ def pytest_addoption(parser):
     parser.addoption("--run-only", action="store", default="")
     parser.addoption("--headless", action="store_true", default=False)
 
+
 @pytest.fixture
 def headless(request):
     return request.config.getoption("--headless")
@@ -65,7 +66,6 @@ def api_test_client(request):
     with TestClient(app) as tc:
         request.cls.client = tc
         yield
-
 
 
 @pytest.fixture(scope="class")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -55,13 +55,13 @@ class TestCrawlAPI:
     crawl_id_2 = None
 
     params = {
-            'browser': 'chrome:67',
-            'screenshot_target_uri': 'file://test',
-            'user_params': {'some': 'value', 'some_int': 7},
-            'behavior_max_time': 30,
-            'headless': False,
-            'start': False,
-            'num_tabs': 2,
+        'browser': 'chrome:67',
+        'screenshot_target_uri': 'file://test',
+        'user_params': {'some': 'value', 'some_int': 7},
+        'behavior_max_time': 30,
+        'headless': False,
+        'start': False,
+        'num_tabs': 2,
     }
 
     def test_crawl_create(self):
@@ -69,9 +69,7 @@ class TestCrawlAPI:
         params['crawl_type'] = 'all-links'
         params['name'] = 'First Crawl!'
 
-        res = self.client.post(
-            '/crawls', json=params
-        )
+        res = self.client.post('/crawls', json=params)
 
         res = res.json()
         assert res['success']
@@ -100,7 +98,7 @@ class TestCrawlAPI:
         assert json['num_tabs'] == 2
         assert json['crawl_type'] == 'all-links'
         assert json['status'] == 'new'
-        assert json['crawl_depth'] == 1
+        assert json['crawl_depth'] == -1
         assert json['start_time'] == 0
         assert json['finish_time'] == 0
         assert json['coll'] == 'live'
@@ -133,9 +131,7 @@ class TestCrawlAPI:
     def test_crawl_same_domain_scopes(self):
         params = self.params.copy()
         params['crawl_type'] = 'same-domain'
-        res = self.client.post(
-            '/crawls', json=params
-        )
+        res = self.client.post('/crawls', json=params)
         assert res.json()['success'] == True
 
         crawl_id = res.json()['id']
@@ -161,8 +157,6 @@ class TestCrawlAPI:
             '/flock/request/browsers?pool=test-pool',
             '/flock/request/browsers?pool=test-pool',
         ]
-
-
 
     def test_get_all_crawls(self):
         res = self.client.get(f'/crawls')
@@ -210,7 +204,10 @@ class TestCrawlAPI:
         # two browsers started
         assert set(json['browsers']) == {'ID_1', 'ID_2'}
 
-        assert set(shepherd_api_urls['start']) == {'/flock/start/ID_1', '/flock/start/ID_2'}
+        assert set(shepherd_api_urls['start']) == {
+            '/flock/start/ID_1',
+            '/flock/start/ID_2',
+        }
 
         # shepherd api post data
         for data in shepherd_api_post_datas['request']:
@@ -221,7 +218,7 @@ class TestCrawlAPI:
 
             assert data['deferred'] == {'autobrowser': False}
 
-            #assert data['environ']['SCREENSHOT_TARGET_URI'] == 'file://test'
+            # assert data['environ']['SCREENSHOT_TARGET_URI'] == 'file://test'
 
             assert data['user_params']['some'] == 'value'
             assert data['user_params']['some_int'] == 7
@@ -293,25 +290,22 @@ class TestCrawlAPI:
     @patch('browsertrix.crawl.CrawlManager.do_request', mock_shepherd_api)
     def test_create_and_start(self):
         res = self.client.post(
-            '/crawls', json={'num_tabs': 2,
-                             'crawl_type': 'all-links',
-                             'name': 'Second Crawl Auto Start!',
-                             'num_browsers': 3,
-                             'coll': 'custom',
-                             'screenshot_coll': 'screen-coll',
-                             'seed_urls':
-                                [
-                                  'https://example.com/',
-                                  'https://iana.org/'
-                                ],
-                             'browser': 'chrome:67',
-                             'screenshot_target_uri': 'file://test',
-                             'user_params': {'some': 'value', 'some_int': 7},
-                             'behavior_max_time': 30,
-                             'headless': True,
-                             'start': True,
-                             }
-
+            '/crawls',
+            json={
+                'num_tabs': 2,
+                'crawl_type': 'all-links',
+                'name': 'Second Crawl Auto Start!',
+                'num_browsers': 3,
+                'coll': 'custom',
+                'screenshot_coll': 'screen-coll',
+                'seed_urls': ['https://example.com/', 'https://iana.org/'],
+                'browser': 'chrome:67',
+                'screenshot_target_uri': 'file://test',
+                'user_params': {'some': 'value', 'some_int': 7},
+                'behavior_max_time': 30,
+                'headless': True,
+                'start': True,
+            },
         )
 
         json = res.json()
@@ -376,4 +370,3 @@ class TestCrawlAPI:
         assert shepherd_api_post_datas['remove'] == [None] * 7
 
         assert fakeredis.FakeStrictRedis().keys('a:*') == []
-

--- a/tests/test_live_crawl.py
+++ b/tests/test_live_crawl.py
@@ -79,6 +79,7 @@ class TestCrawls(object):
 
     def test_replay(self, crawl):
         for seen_url in self.seen:
-            res = requests.get(f'http://localhost:8181/coll/mp_/{seen_url}', allow_redirects=True)
+            res = requests.get(
+                f'http://localhost:8181/coll/mp_/{seen_url}', allow_redirects=True
+            )
             assert 'URL Not Found' not in res.text
-

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -3,10 +3,7 @@ import json
 
 import fakeredis
 
-__all__ = [
-    'AwaitFakeRedis',
-    'init_fake_redis',
-]
+__all__ = ['AwaitFakeRedis', 'init_fake_redis']
 
 
 class AwaitFakeRedis:


### PR DESCRIPTION
## Why
Using and enforcing hard-coded crawl depth is not the expected behavior of a crawler.
We allow setting defaults via environment variable if one must set a hard limit. 

## Summary
api:
  - switched to named import from * when importing schemas

crawl:
  - removed the hardcoded default crawl depth in favor of infinite depth -1 (ref issue #30)
  - refactored to use project type definitions

schema:
  - refactored to use project type definitions

utils:
  - refactored to use project type definitions

scripts:
  - added tests dir to files to be formatted and formatted the project

requirements:
  - bumped fastapi version